### PR TITLE
Add ByAmount keys to credited user list

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -38,3 +38,5 @@ export interface CurrentStreamCredits {
     [CreditTypes.SUB]: CreditedUserEntry[];
     [CreditTypes.VIP]: CreditedUserEntry[];
 }
+
+export const existingCategories = ['existingAllSubs', 'existingFollowers', 'existingGiftedSubs', 'existingGifters', 'existingPaidSubs'];


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds `ByAmount` to category lists to indicate sorting by amount (default is sorting by username).

For example:

```
$creditedUserList[cheer] // Sorted by username
$creditedUserList[cheerByAmount] // Sorted by amount of bits given, highest first
```

This also works in `$creditedUserListJSON` and keys for `xyzByAmount` are added when all keys are shown.

### Motivation
Sometimes it's desirable to sort by amount instead of by username.

### Testing
Generated some simulated events and made sure that all of these new variables worked as intended.
