### PR TITLE
Provide ability to do simple HTML changes for entries

### DIFF
--- a/browser-source-files/credits.js
+++ b/browser-source-files/credits.js
@@ -8,10 +8,25 @@ window.onload = function() {
     const parsedData = JSON.parse(atob(data));
     let hasPreviousSection = false;
     for (const section of sectionsConfig) {
+        if (!section.hasOwnProperty('header')) {
+            console.warn('Section is missing required "header" property:', section);
+            continue;
+        }
+
+        if (!section.hasOwnProperty('key')) {
+            console.warn('Section is missing required "key" property:', section);
+            continue;
+        }
+
         const entries = parsedData[section.key] || [];
         if (entries.length === 0) {
             console.log(`Skipping section: ${section.header} (${section.key}: no entries)`);
             continue;
+        }
+
+        let htmlCode = '{image}<p class="user-display-name">{displayName}</p>';
+        if (section.hasOwnProperty('html')) {
+            htmlCode = section.html;
         }
 
         if (hasPreviousSection) {
@@ -33,12 +48,17 @@ window.onload = function() {
             console.log(`Adding entry: ${entry.displayName} (${section.header})`);
             const entryDiv = document.createElement('div');
             entryDiv.className = 'entry';
-            entryDiv.innerHTML = `<img src="${entry.profilePicUrl}" alt="${entry.username}'s avatar" class="avatar" /><p class="user-display-name">${entry.displayName}</p>`;
-            sectionDiv.appendChild(entryDiv);
 
-            // Force loading the image to ensure it is cached
             const img = new Image();
             img.src = entry.profilePicUrl;
+            img.alt = `${entry.username}'s avatar`;
+            img.className = 'avatar';
+
+            entryDiv.innerHTML = htmlCode
+                .replace('{image}', img.outerHTML)
+                .replace('{displayName}', entry.displayName)
+                .replace('{amount}', entry.amount);
+            sectionDiv.appendChild(entryDiv);
         }
 
         creditsContainer.appendChild(sectionDiv);


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds a field 'html' to the credit configuration to allow the user to change the display for any section.

This recognizes replacements:
- `{image}` replaced with the image HTML for the profile avatar (class = "avatar")
- `{displayName}` replaced with the user display name
- `{amount}` replaced with the amount

The default, which matches how this worked before and what is shown in the video, is:

`{image}<p class="user-display-name">{displayName}</p>`

### Motivation
Gives flexibility to customize the display. Personally I'm intending to add the number of months subscribed, once that becomes the "amount" for existing subscriber variables.

### Testing
Ran credits in browser with a customized entry.
