### PR TITLE
Bugfix: Built-in gift sub event should record quantity 1

### DIFF
--- a/src/effects/register-credit.ts
+++ b/src/effects/register-credit.ts
@@ -127,8 +127,8 @@ export const registerCreditEffect: Firebot.EffectType<registerCreditEffectParams
                     return;
                 }
 
-                currentStreamCredits[CreditTypes.GIFT].push({username: username, amount: forceNumber(trigger.metadata?.eventData?.subCount || 0)});
-                logger.debug(`Registered subs gifted from ${eventSourceAndType} for user ${username} (${forceNumber(trigger.metadata?.eventData?.subCount || 0)}).`);
+                currentStreamCredits[CreditTypes.GIFT].push({username: username, amount: forceNumber(trigger.metadata?.eventData?.subCount || 1)});
+                logger.debug(`Registered subs gifted from ${eventSourceAndType} for user ${username} (${forceNumber(trigger.metadata?.eventData?.subCount || 1)}).`);
                 break;
             }
             case 'twitch:raid': {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
The credit registered for an individual gift sub should default to 1, not 0.

### Motivation
When community subs are given, `subCount` is set, and this worked. But for an individual gift sub, `subCount` was not set, so this recorded 0. If someone gave 5 community subs and then gave 2 individual subs, this would have recorded as 5 before (5 + 0 + 0 = 5). This now records correctly as 7 (5 + 1 + 1 = 7).

### Testing
Simulated events and confirmed amount was correct.
