### PR TITLE
Use transform and performance for smoother scrolling

### DIFF
--- a/browser-source-files/credits.js
+++ b/browser-source-files/credits.js
@@ -1,5 +1,4 @@
 window.onload = function() {
-    const startTime = Date.now();
     const creditsContainer = document.getElementById('credits-container');
     creditsContainer.innerHTML = '';
     const creditsContainerParentHeight = creditsContainer.parentElement.offsetHeight;
@@ -112,10 +111,12 @@ window.onload = function() {
     creditsContainer.style.top = `${creditsContainerParentHeight + config.extraPanelPadding - (creditsContainerParentHeight + creditsContainerHeight + config.extraPanelPadding)}px`;
     creditsContainer.parentElement.style.display = 'block';
 
+    const startTime = performance.now();
+
     function animate() {
-        const elapsedTime = Date.now() - startTime;
+        const elapsedTime = performance.now() - startTime;
         const progress = Math.min(elapsedTime / totalDuration, 1);
-        creditsContainer.style.top = `${creditsContainerParentHeight + config.extraPanelPadding - (creditsContainerParentHeight + creditsContainerHeight + config.extraPanelPadding) * progress}px`;
+        creditsContainer.style.transform = `translateY(${(creditsContainerParentHeight + creditsContainerHeight + config.extraPanelPadding) * (1-progress)}px)`;
 
         if (progress < 1) {
             requestAnimationFrame(animate);


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Uses `performance.now()` instead of `Date.now()` and `creditsContainer.style.transform` instead of `creditsContainer.style.top` to control animation.

### Motivation
Smoother scrolling.

### Testing
Tested with credits on stream.
