### PR TITLE
Dedicated "write data file" effect for easier configuration

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -8,6 +8,8 @@
 
         (File &gt; Open Data Folder, then select the "scripts" directory)
 
+    :warning: Be sure you download the file from the releases page, not the source code of the GitHub repository!
+
 2. Enable custom scripts in Firebot (Settings &gt; Scripts) if you have not already done so.
 
 3. Go to Settings &gt; Scripts &gt; Manage Startup Scripts &gt; Add New Script and add the `firebot-mage-credits-generator-<version>.js` script.
@@ -70,15 +72,9 @@ You'll need this URL for step 2 in the next section.
 
 Create a Preset Effect List (perhaps called "Roll Credits") containing the following effects:
 
-1. **Write To File**
+1. **Credit Generator: Write data file**
 
     - File: Choose the `credits-json.js` file that you installed with the browser files
-    - Write Mode: Replace
-    - Text: _Copy and paste the following exactly as it appears below_
-        ```text
-        // File maintained by Firebot -- DO NOT EDIT
-        const data = `$creditedUserListBase64encode[$creditedUserListJSON]`;
-        ```
 
 2. **Set OBS Browser Source URL**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mage-credits-generator",
     "scriptOutputName": "mage-credits-generator",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Effects and variables to generate rolling credits on screen",
     "main": "",
     "scripts": {

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -2,11 +2,13 @@ import { RunRequest } from '@crowbartools/firebot-custom-scripts-types';
 import { registerCreditEffect } from './register-credit';
 import { registerCreditManualEffect } from './register-credit-manual';
 import { registerCustomCreditEffect } from './register-custom-credit';
+import { writeDataFileEffect } from './write-data-file';
 
 export function registerEffects(firebot: RunRequest<any>) {
     const { effectManager } = firebot.modules;
     effectManager.registerEffect(registerCreditEffect);
     effectManager.registerEffect(registerCreditManualEffect);
+    effectManager.registerEffect(writeDataFileEffect);
 
     if (firebot.parameters.enableCustomCredits) {
         // This is an advanced effect that allows users to register custom

--- a/src/effects/write-data-file.ts
+++ b/src/effects/write-data-file.ts
@@ -1,0 +1,52 @@
+import { Firebot } from '@crowbartools/firebot-custom-scripts-types';
+import { firebot, logger } from '../main';
+import { base64EncodeReplaceVariable } from '../variables/base64encode';
+import { creditedUserListJSON } from '../variables/credited-user-list';
+
+type effectParams = {
+    filepath: string;
+};
+
+export const writeDataFileEffect: Firebot.EffectType<effectParams> = {
+    definition: {
+        id: "magecredits:writeDataFile",
+        name: "Credit Generator: Write data file",
+        description: "Write data to a file for the credits tracking system.",
+        icon: "fad fa-comment-alt",
+        categories: ["scripting"]
+    },
+    optionsTemplate: `
+        <eos-container header="File">
+            <file-chooser model="effect.filepath" options="{ filters: [ {name:'JavaScript',extensions:['js']}, {name:'All Files',extensions:['*']} ]}"></file-chooser>
+        </eos-container>
+    `,
+    optionsController: () => {
+        // This effect does not require a specific options controller.
+    },
+    optionsValidator: (effect: effectParams) => {
+        const errors = [];
+        if (effect.filepath == null || effect.filepath === "") {
+            errors.push("Please select a text file to write to.");
+        }
+        return errors;
+    },
+    onTriggerEvent: async (event) => {
+        const { effect, trigger } = event;
+        const { fs } = firebot.modules;
+
+        const header = `// File maintained by Firebot -- DO NOT EDIT\n`;
+        const jsonData = await creditedUserListJSON.evaluator(trigger);
+        const data = await base64EncodeReplaceVariable.evaluator(trigger, jsonData as string);
+        const content = `${header}\nconst data = "${data}";\n`;
+
+        try {
+            fs.writeFileSync(effect.filepath, content, 'utf8');
+            logger.info(`Data successfully written to ${effect.filepath}`);
+            return { success: true };
+        } catch (error) {
+            const errorMsg = (error instanceof Error) ? error.message : String(error);
+            logger.error(`Failed to write data to ${effect.filepath}: ${errorMsg}`);
+            return { success: false, error: errorMsg };
+        }
+    }
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ export const currentStreamCredits: CurrentStreamCredits = {
 export let firebot: RunRequest<any>;
 export let logger: Logger;
 
-const scriptVersion = '0.0.3';
+const scriptVersion = '0.0.4';
 
 const script: Firebot.CustomScript<Parameters> = {
     getScriptManifest: () => {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Add a custom effect to the script to write the data file.

<img width="598" height="330" alt="image" src="https://github.com/user-attachments/assets/7832c48d-0c96-4efa-b0b8-8de103dcff48" />


### Motivation
The previous instructions do work, but it's difficult because Firebot hard-codes the extension of the file to TXT and so you need to know the exact name of the file. This effect just hard-codes everything so it's easier to set up.

### Testing
Works on my machine :smile_cat: 
