### PR TITLE
Replace Kick logo with default Twitch pic

### DIFF
--- a/src/variables/credited-user-list.ts
+++ b/src/variables/credited-user-list.ts
@@ -182,6 +182,19 @@ export const creditedUserListJSON: ReplaceVariable = {
 
                 const userObjects = await Promise.all(users.map((entry: CreditedUserEntry) => getUserObject(entry)));
                 const result = userObjects.filter((entry): entry is NonNullable<typeof entry> => entry !== undefined);
+
+                // Twitch seems to have an inferiority complex or insecurity
+                // about their competitor Kick, but I won't want anyone to get
+                // banned on my account for showing the Kick logo on a Twitch
+                // stream. But this workaround is Kick's fault anyway, since
+                // their profile picture URLs are broken
+                // (https://github.com/KickEngineering/KickDevDocs/issues/166)
+                // so we will replace it with a Twitch default profile picture.
+                for (const entry of result) {
+                    if (entry.profilePicUrl === "https://kick.com/favicon.ico") {
+                        entry.profilePicUrl = "https://static-cdn.jtvnw.net/user-default-pictures-uv/ead5c8b2-a4c9-4724-b1dd-9f00b46cbd3d-profile_image-300x300.png";
+                    }
+                }
                 results[fullCategory] = result;
             }
         }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Replaces `https://kick.com/favicon.ico` with ![Twitch Default](https://static-cdn.jtvnw.net/user-default-pictures-uv/ead5c8b2-a4c9-4724-b1dd-9f00b46cbd3d-profile_image-300x300.png) in user profile images.

### Motivation
There's an experimental integration between Kick and Firebot that uses the Kick logo as the user's icon because Kick's user profile pictures are inaccessible unless sourced from a page on kick.com.

Twitch seems to be insecure about anything Kick related, and I don't want any Twitch streamer getting banned for unknowingly showing the Kick logo on their stream. This hopefully makes things "safe" to show on Twitch for anyone who may be using this integration.

### Testing
Tested on my machine with the Kick integration and it works.
