### PR TITLE
Support kick hosts

### DIFF
--- a/src/effects/register-credit.ts
+++ b/src/effects/register-credit.ts
@@ -19,6 +19,7 @@ triggers["event"] = [
     // 'streamlabs:follow', TODO support in future
     'twitch:community-subs-gifted',
     'twitch:subs-gifted',
+    'mage-kick-integration:raid', // Kick hosts
     'twitch:raid',
     'twitch:sub',
     'twitch:gift-sub-upgraded',
@@ -159,6 +160,7 @@ export const registerCreditEffect: Firebot.EffectType<registerCreditEffectParams
                 logger.debug(`Registered subs gifted from ${eventSourceAndType} for user ${username} (${forceNumber(trigger.metadata?.eventData?.subCount || 1)}).`);
                 break;
             }
+            case 'mage-kick-integration:raid':
             case 'twitch:raid': {
                 const username = trigger.metadata?.username;
                 if (!username) {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This allows the "Register Credit" effect to be used for Kick hosts (these are registered as, and commingled with, raids).

Note: This requires a version of my Kick integration at or after https://github.com/TheStaticMage/firebot-mage-kick-integration/pull/32.

### Motivation
Keep parity with Kick and Twitch events as the Kick integration evolves.

### Testing
Simulated event and rolled credits.
