### PR TITLE
Add combo to built-in effect register

### DIFF
--- a/src/effects/register-credit.ts
+++ b/src/effects/register-credit.ts
@@ -9,6 +9,7 @@ type registerCreditEffectParams = Record<string, never>;
 const triggers: Effects.TriggersObject = {};
 triggers["event"] = [
     'twitch:cheer',
+    'combo-event:bits-combo', // https://github.com/TheStaticMage/firebot-combo-event
     // 'extralife:donation', TODO support in future
     'streamelements:donation',
     // 'streamlabs:donation', TODO support in future
@@ -75,8 +76,8 @@ export const registerCreditEffect: Firebot.EffectType<registerCreditEffectParams
 
         const eventSourceAndType = `${eventSource}:${eventType}`;
 
-
         switch (eventSourceAndType) {
+            case 'combo-event:bits-combo':
             case 'twitch:cheer': {
                 const username = trigger.metadata?.username;
                 if (!username) {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds the "combo" event to the allowed triggers for the "Register Credit" event and registers this as a cheer.

:warning: Combos are not supported by Firebot yet, and they have indicated there is no plan to support them until the feature comes out of beta. This event supports my implementation in <https://github.com/TheStaticMage/firebot-combo-event>.

### Motivation
People cheer in combos on my stream and I want to recognize them for doing so.

### Testing
Tested on my stream.