### PR TITLE
Handle donation from non-Twitch user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mage-credits-generator",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mage-credits-generator",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "license": "GNU3",
             "dependencies": {
                 "node-cache": "^5.1.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mage-credits-generator",
     "scriptOutputName": "mage-credits-generator",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "description": "Effects and variables to generate rolling credits on screen",
     "main": "",
     "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export let firebot: RunRequest<any>;
 export let logger: Logger;
 export let server: Server | null = null;
 
-const scriptVersion = '0.2.4';
+const scriptVersion = '0.2.5';
 
 const script: Firebot.CustomScript<Parameters> = {
     getScriptManifest: () => {

--- a/tests/register-credit.test.ts
+++ b/tests/register-credit.test.ts
@@ -24,10 +24,10 @@ jest.mock('../src/main', () => ({
     }
 }));
 
-import { registerCreditEffect } from '../src/effects/register-credit';
+import { registerCreditsEffectController } from '../src/effects/register-credit';
 import { CreditTypes } from '../src/types';
 
-describe('registerCreditEffect.onTriggerEvent', () => {
+describe('registerCreditsEffectController.onTriggerEvent', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockRegisterCredit.mockReturnValue(true);
@@ -50,7 +50,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -65,7 +65,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -77,7 +77,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -96,7 +96,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.CHEER,
@@ -121,7 +121,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.CHEER,
@@ -146,7 +146,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -163,7 +163,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.CHEER,
@@ -190,7 +190,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.CHEER,
@@ -215,7 +215,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.CHEER,
@@ -240,7 +240,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.CHEER,
@@ -265,7 +265,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -282,7 +282,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -299,105 +299,8 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
-            expect(mockRegisterCredit).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('StreamElements donation events', () => {
-        it('should register donation event', async () => {
-            mockGetTwitchUserByUsername.mockResolvedValue({
-                username: 'donoruser',
-                displayName: 'Donor User',
-                profilePicUrl: 'https://example.com/donor.jpg',
-                twitchRoles: []
-            });
-
-            const event = {
-                trigger: {
-                    metadata: {
-                        eventSource: { id: 'streamelements' },
-                        event: { id: 'donation' },
-                        eventData: {
-                            from: 'donoruser',
-                            donationAmount: 25.50
-                        }
-                    }
-                }
-            };
-
-            await registerCreditEffect.onTriggerEvent(event as any);
-
-            expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('donoruser');
-            expect(mockRegisterCredit).toHaveBeenCalledWith(
-                CreditTypes.DONATION,
-                {
-                    username: 'donoruser',
-                    amount: 25.50,
-                    userDisplayName: 'Donor User',
-                    profilePicUrl: 'https://example.com/donor.jpg'
-                }
-            );
-        });
-
-        it('should not register donation with missing from field', async () => {
-            const event = {
-                trigger: {
-                    metadata: {
-                        eventSource: { id: 'streamelements' },
-                        event: { id: 'donation' },
-                        eventData: {
-                            donationAmount: 25.50
-                            // from missing
-                        }
-                    }
-                }
-            };
-
-            await registerCreditEffect.onTriggerEvent(event as any);
-
-            expect(mockRegisterCredit).not.toHaveBeenCalled();
-        });
-
-        it('should not register donation with invalid amount', async () => {
-            const event = {
-                trigger: {
-                    metadata: {
-                        eventSource: { id: 'streamelements' },
-                        event: { id: 'donation' },
-                        eventData: {
-                            from: 'donoruser',
-                            donationAmount: 'invalid'
-                        }
-                    }
-                }
-            };
-
-            await registerCreditEffect.onTriggerEvent(event as any);
-
-            expect(mockRegisterCredit).not.toHaveBeenCalled();
-        });
-
-        it('should not register donation when user not found in database', async () => {
-            mockGetTwitchUserByUsername.mockResolvedValue(null);
-
-            const event = {
-                trigger: {
-                    metadata: {
-                        eventSource: { id: 'streamelements' },
-                        event: { id: 'donation' },
-                        eventData: {
-                            from: 'unknownuser',
-                            donationAmount: 10.00
-                        }
-                    }
-                }
-            };
-
-            await registerCreditEffect.onTriggerEvent(event as any);
-
-            expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('unknownuser');
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
     });
@@ -418,7 +321,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.FOLLOW,
@@ -447,7 +350,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.FOLLOW,
@@ -472,7 +375,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.FOLLOW,
@@ -496,7 +399,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -514,7 +417,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -530,7 +433,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -548,7 +451,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.SUB,
@@ -572,7 +475,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.SUB,
@@ -596,7 +499,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.SUB,
@@ -620,7 +523,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -642,7 +545,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.GIFT,
@@ -670,7 +573,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.GIFT,
@@ -698,7 +601,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.GIFT,
@@ -726,7 +629,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.GIFT,
@@ -754,7 +657,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -774,7 +677,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -795,7 +698,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.RAID,
@@ -822,7 +725,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.RAID,
@@ -849,7 +752,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.RAID,
@@ -874,7 +777,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).toHaveBeenCalledWith(
                 CreditTypes.RAID,
@@ -901,7 +804,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockRegisterCredit).not.toHaveBeenCalled();
         });
@@ -926,7 +829,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('vipuser');
             expect(mockRegisterCredit).toHaveBeenCalledWith(
@@ -958,7 +861,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('moduser');
             expect(mockRegisterCredit).toHaveBeenCalledWith(
@@ -990,7 +893,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('supervipmod');
             expect(mockRegisterCredit).toHaveBeenCalledTimes(2);
@@ -1032,7 +935,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('regularuser');
             expect(mockRegisterCredit).not.toHaveBeenCalled();
@@ -1056,7 +959,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('noroleuser');
             expect(mockRegisterCredit).not.toHaveBeenCalled();
@@ -1075,7 +978,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockGetTwitchUserByUsername).toHaveBeenCalledWith('unknownviewer');
             expect(mockRegisterCredit).not.toHaveBeenCalled();
@@ -1092,7 +995,7 @@ describe('registerCreditEffect.onTriggerEvent', () => {
                 }
             };
 
-            await registerCreditEffect.onTriggerEvent(event as any);
+            await registerCreditsEffectController.onTriggerEvent(event as any);
 
             expect(mockGetTwitchUserByUsername).not.toHaveBeenCalled();
             expect(mockRegisterCredit).not.toHaveBeenCalled();

--- a/tests/register-credits-effect-controller-donation.test.ts
+++ b/tests/register-credits-effect-controller-donation.test.ts
@@ -1,0 +1,233 @@
+// Mock the dependencies
+const mockGetViewerByUsername = jest.fn();
+
+jest.mock('../src/main', () => ({
+    firebot: {
+        modules: {
+            viewerDatabase: {
+                getViewerByUsername: mockGetViewerByUsername
+            }
+        }
+    },
+    logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn()
+    }
+}));
+
+import { registerCreditsEffectController } from '../src/effects/register-credit';
+import { currentStreamCredits } from '../src/credits-store';
+import { CreditTypes } from '../src/types';
+
+describe('RegisterCreditsEffectController.onTriggerEvent - StreamElements Donation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Clear all credits before each test
+        currentStreamCredits.clearAllCredits();
+    });
+
+    it('should register donation event and credit should be retrievable via getCreditsForType', async () => {
+        // Mock viewer database response
+        const mockUser = {
+            username: 'donoruser',
+            displayName: 'Donor User',
+            profilePicUrl: 'https://example.com/donor.jpg'
+        };
+        mockGetViewerByUsername.mockResolvedValue(mockUser);
+
+        // The expected credit that will be registered
+        const expectedCredit = {
+            username: 'donoruser',
+            amount: 25.50,
+            userDisplayName: 'Donor User',
+            profilePicUrl: 'https://example.com/donor.jpg'
+        };
+
+        const event = {
+            effect: {},
+            trigger: {
+                metadata: {
+                    eventSource: { id: 'streamelements' },
+                    event: { id: 'donation' },
+                    eventData: {
+                        from: 'donoruser',
+                        donationAmount: 25.50
+                    }
+                }
+            },
+            sendDataToOverlay: jest.fn(),
+            outputs: {},
+            abortSignal: new AbortController().signal
+        };
+
+        // Execute the method under test
+        await registerCreditsEffectController.onTriggerEvent(event as any);
+
+        // Verify that the viewer database was called correctly
+        expect(mockGetViewerByUsername).toHaveBeenCalledWith('donoruser');
+
+        // Verify that the credit can be retrieved via getCreditsForType
+        const retrievedCredits = currentStreamCredits.getCreditsForType(CreditTypes.DONATION);
+        expect(retrievedCredits).not.toBeNull();
+        expect(retrievedCredits).toHaveLength(1);
+
+        if (retrievedCredits) {
+            expect(retrievedCredits[0]).toEqual(expectedCredit);
+        }
+    });
+
+    it('should handle a donor name with a space the maps to a username', async () => {
+        // Mock viewer database response
+        const mockUser = {
+            username: 'donoruser',
+            displayName: 'Donor User',
+            profilePicUrl: 'https://example.com/donor.jpg'
+        };
+        mockGetViewerByUsername.mockResolvedValue(mockUser);
+
+        // The expected credit that will be registered
+        const expectedCredit = {
+            username: 'donoruser',
+            amount: 25.50,
+            userDisplayName: 'Donor User',
+            profilePicUrl: 'https://example.com/donor.jpg'
+        };
+
+        const event = {
+            effect: {},
+            trigger: {
+                metadata: {
+                    eventSource: { id: 'streamelements' },
+                    event: { id: 'donation' },
+                    eventData: {
+                        from: 'Donor User', // Name with space
+                        donationAmount: 25.50
+                    }
+                }
+            },
+            sendDataToOverlay: jest.fn(),
+            outputs: {},
+            abortSignal: new AbortController().signal
+        };
+
+        // Execute the method under test
+        await registerCreditsEffectController.onTriggerEvent(event as any);
+
+        // Verify that the viewer database was called correctly
+        expect(mockGetViewerByUsername).toHaveBeenCalledWith('donoruser');
+
+        // Verify that the credit can be retrieved via getCreditsForType
+        const retrievedCredits = currentStreamCredits.getCreditsForType(CreditTypes.DONATION);
+        expect(retrievedCredits).not.toBeNull();
+        expect(retrievedCredits).toHaveLength(1);
+
+        if (retrievedCredits) {
+            expect(retrievedCredits[0]).toEqual(expectedCredit);
+        }
+    });
+
+    it('should handle donation when user not found in database', async () => {
+        // Mock viewer database to return null (user not found)
+        mockGetViewerByUsername.mockResolvedValue(null);
+
+        // The expected credit with best guess username
+        const expectedCredit = {
+            username: 'unknownuser',
+            amount: 10.00,
+            userDisplayName: 'unknownuser',
+            profilePicUrl: ''
+        };
+
+        const event = {
+            effect: {},
+            trigger: {
+                metadata: {
+                    eventSource: { id: 'streamelements' },
+                    event: { id: 'donation' },
+                    eventData: {
+                        from: 'unknownuser',
+                        donationAmount: 10.00
+                    }
+                }
+            },
+            sendDataToOverlay: jest.fn(),
+            outputs: {},
+            abortSignal: new AbortController().signal
+        };
+
+        // Execute the method under test
+        await registerCreditsEffectController.onTriggerEvent(event as any);
+
+        // Verify that the viewer database was called
+        expect(mockGetViewerByUsername).toHaveBeenCalledWith('unknownuser');
+
+        // Verify that the credit can be retrieved via getCreditsForType
+        const retrievedCredits = currentStreamCredits.getCreditsForType(CreditTypes.DONATION);
+        expect(retrievedCredits).not.toBeNull();
+        expect(retrievedCredits).toHaveLength(1);
+
+        if (retrievedCredits) {
+            expect(retrievedCredits[0]).toEqual(expectedCredit);
+        }
+    });
+
+    it('should not register donation with missing from field', async () => {
+        const event = {
+            effect: {},
+            trigger: {
+                metadata: {
+                    eventSource: { id: 'streamelements' },
+                    event: { id: 'donation' },
+                    eventData: {
+                        donationAmount: 25.50
+                        // from field missing
+                    }
+                }
+            },
+            sendDataToOverlay: jest.fn(),
+            outputs: {},
+            abortSignal: new AbortController().signal
+        };
+
+        // Execute the method under test
+        await registerCreditsEffectController.onTriggerEvent(event as any);
+
+        // Verify that no database call was made
+        expect(mockGetViewerByUsername).not.toHaveBeenCalled();
+
+        // Verify that no credit was registered
+        const retrievedCredits = currentStreamCredits.getCreditsForType(CreditTypes.DONATION);
+        expect(retrievedCredits).toEqual([]);
+    });
+
+    it('should not register donation with invalid amount', async () => {
+        const event = {
+            effect: {},
+            trigger: {
+                metadata: {
+                    eventSource: { id: 'streamelements' },
+                    event: { id: 'donation' },
+                    eventData: {
+                        from: 'donoruser',
+                        donationAmount: 'invalid'
+                    }
+                }
+            },
+            sendDataToOverlay: jest.fn(),
+            outputs: {},
+            abortSignal: new AbortController().signal
+        };
+
+        // Execute the method under test
+        await registerCreditsEffectController.onTriggerEvent(event as any);
+
+        // Verify that no database call was made
+        expect(mockGetViewerByUsername).not.toHaveBeenCalled();
+
+        // Verify that no credit was registered
+        const retrievedCredits = currentStreamCredits.getCreditsForType(CreditTypes.DONATION);
+        expect(retrievedCredits).toEqual([]);
+    });
+});


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
If a user logs in as a YouTube user whose name does not match their Twitch username, or the streamer has things set up to let people type arbitrary names, the default "register credit" effect will now register the donor name instead of skipping this with an error.

### Motivation
The user "`[Error]`" donated to one of the streamers who uses this today and didn't get credit... :crying_cat_face: 

### Testing
Unit test updated + simulated events in Firebot.
